### PR TITLE
adds reserved_concurrent_executions to lambda

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,17 @@
 module "lambda" {
-  source        = "./modules/lambda"
-  description   = var.description
-  environment   = var.environment
-  filename      = var.filename
-  function_name = var.function_name
-  handler       = var.handler
-  memory_size   = var.memory_size
-  publish       = var.publish
-  runtime       = var.runtime
-  timeout       = var.timeout
-  tags          = var.tags
-  vpc_config    = var.vpc_config
+  source                         = "./modules/lambda"
+  description                    = var.description
+  environment                    = var.environment
+  filename                       = var.filename
+  function_name                  = var.function_name
+  handler                        = var.handler
+  memory_size                    = var.memory_size
+  publish                        = var.publish
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  runtime                        = var.runtime
+  timeout                        = var.timeout
+  tags                           = var.tags
+  vpc_config                     = var.vpc_config
 }
 
 module "event-cloudwatch-scheduled-event" {

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -6,16 +6,17 @@ resource "aws_lambda_function" "lambda" {
       variables = environment.value.variables
     }
   }
-  filename         = var.filename
-  function_name    = var.function_name
-  handler          = var.handler
-  memory_size      = var.memory_size
-  publish          = var.publish
-  role             = aws_iam_role.lambda.arn
-  runtime          = var.runtime
-  source_code_hash = filebase64sha256(var.filename)
-  tags             = var.tags
-  timeout          = var.timeout
+  filename                       = var.filename
+  function_name                  = var.function_name
+  handler                        = var.handler
+  memory_size                    = var.memory_size
+  publish                        = var.publish
+  reserved_concurrent_executions = var.reserved_concurrent_executions
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = var.runtime
+  source_code_hash               = filebase64sha256(var.filename)
+  tags                           = var.tags
+  timeout                        = var.timeout
 
   dynamic "vpc_config" {
     for_each = length(var.vpc_config) < 1 ? [] : [var.vpc_config]

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -45,6 +45,11 @@ variable "publish" {
   default     = false
 }
 
+variable "reserved_concurrent_executions" {
+  description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1."
+  default     = "-1"
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to the Lambda function."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,11 @@ variable "publish" {
   default     = true
 }
 
+variable "reserved_concurrent_executions" {
+  description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1."
+  default     = "-1"
+}
+
 variable "runtime" {
   description = "The runtime environment for the Lambda function you are uploading. Defaults to go1.x"
   default     = "go1.x"


### PR DESCRIPTION
This adds `reserved_concurrent_executions` argument to the lambda module https://www.terraform.io/docs/providers/aws/r/lambda_function.html#reserved_concurrent_executions. The default remains unreserved concurrency. 