### PR TITLE
Refactoring of stream event source mappings

### DIFF
--- a/examples/example-with-dynamodb-event/main.tf
+++ b/examples/example-with-dynamodb-event/main.tf
@@ -9,9 +9,8 @@ module "lambda" {
   handler       = "my-handler"
 
   event = {
-    type                    = "dynamodb"
-    stream_event_source_arn = "arn:aws:dynamodb:eu-west-1:647379381847:table/some-table/stream/some-identifier"
-    table_name              = "some-table"
+    type             = "dynamodb"
+    event_source_arn = "arn:aws:dynamodb:eu-west-1:647379381847:table/some-table/stream/some-identifier"
   }
 
   # optionally configure Parameter Store access with decryption

--- a/examples/example-with-kinesis-event/main.tf
+++ b/examples/example-with-kinesis-event/main.tf
@@ -11,7 +11,6 @@ module "lambda" {
   event = {
     type             = "kinesis"
     event_source_arn = "arn:aws:kinesis:eu-west-1:647379381847:stream/my-stream"
-    stream_name      = "my-stream"
   }
 
   # optionally configure Parameter Store access with decryption

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,6 @@ module "event-kinesis" {
   event_source_arn             = lookup(var.event, "event_source_arn", "")
   iam_role_name                = module.lambda.role_name
   starting_position            = lookup(var.event, "starting_position", "TRIM_HORIZON")
-  stream_name                  = lookup(var.event, "stream_name", "")
 }
 
 module "event-sns" {

--- a/main.tf
+++ b/main.tf
@@ -26,10 +26,12 @@ module "event-dynamodb" {
   source = "./modules/event/dynamodb"
   enable = lookup(var.event, "type", "") == "dynamodb" ? true : false
 
-  function_name           = module.lambda.function_name
-  iam_role_name           = module.lambda.role_name
-  stream_event_source_arn = lookup(var.event, "stream_event_source_arn", "")
-  table_name              = lookup(var.event, "table_name", "")
+  batch_size                   = lookup(var.event, "batch_size", 100)
+  event_source_mapping_enabled = lookup(var.event, "event_source_mapping_enabled", true)
+  function_name                = module.lambda.function_name
+  event_source_arn             = lookup(var.event, "event_source_arn", "")
+  iam_role_name                = module.lambda.role_name
+  starting_position            = lookup(var.event, "starting_position", "TRIM_HORIZON")
 }
 
 module "event-kinesis" {

--- a/modules/event/dynamodb/main.tf
+++ b/modules/event/dynamodb/main.tf
@@ -1,27 +1,23 @@
-data "aws_region" "current" {
-}
-
-data "aws_caller_identity" "current" {
-}
-
 resource "aws_lambda_event_source_mapping" "stream_source" {
   count             = var.enable ? 1 : 0
-  event_source_arn  = var.stream_event_source_arn
+  batch_size        = var.batch_size
+  enabled           = var.event_source_mapping_enabled
+  event_source_arn  = var.event_source_arn
   function_name     = var.function_name
-  starting_position = var.stream_starting_position
+  starting_position = var.starting_position
 }
 
+// see https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
 data "aws_iam_policy_document" "stream_policy_document" {
   statement {
     actions = [
       "dynamodb:DescribeStream",
       "dynamodb:GetShardIterator",
-      "dynamodb:GetRecords",
-      "dynamodb:ListStreams",
+      "dynamodb:GetRecords"
     ]
 
     resources = [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.table_name}/stream/*",
+      var.event_source_arn
     ]
   }
 }

--- a/modules/event/dynamodb/variables.tf
+++ b/modules/event/dynamodb/variables.tf
@@ -1,31 +1,41 @@
-variable "enable" {
-  description = "Conditionally enables this module (and all it's ressources)."
-  type        = bool
-  default     = false
-}
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
 
 variable "iam_role_name" {
   description = "The name of the IAM role to attach stream policy configuration."
-  default     = ""
+}
+
+variable "event_source_arn" {
+  description = "Event source ARN of a KinesDynamoDb stream."
 }
 
 variable "function_name" {
   description = "The name or the ARN of the Lambda function that will be subscribing to events. "
-  default     = ""
 }
 
-variable "stream_event_source_arn" {
-  description = "Event source ARN of a DynamoDB stream."
-  default     = ""
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "batch_size" {
+  default     = 100
+  description = "The largest number of records that Lambda will retrieve from your event source at the time of invocation. Defaults to 100 for DynamoDB and Kinesis."
 }
 
-variable "stream_starting_position" {
-  description = "The position in the stream where AWS Lambda should start reading. Must be one of either TRIM_HORIZON or LATEST. Defaults to TRIM_HORIZON."
+variable "enable" {
+  default     = false
+  description = "Conditionally enables this module (and all it's ressources)."
+}
+
+variable "event_source_mapping_enabled" {
+  default     = true
+  description = "Determines if the mapping will be enabled on creation. Defaults to true."
+}
+
+variable "starting_position" {
   default     = "TRIM_HORIZON"
+  description = "The position in the stream where AWS Lambda should start reading. Must be one of either TRIM_HORIZON or LATEST. Defaults to TRIM_HORIZON."
 }
-
-variable "table_name" {
-  description = "The name of the DynamoDb table providing the stream."
-  default     = ""
-}
-

--- a/modules/event/kinesis/main.tf
+++ b/modules/event/kinesis/main.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "stream_policy_document" {
     resources = [
       // extracting 'arn:${Partition}:kinesis:${Region}:${Account}:stream/' from the kinesis stream ARN
       // see https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazonkinesis.html#amazonkinesis-resources-for-iam-policies
-      "${regex("arn.*\\/", var.event_source_arn)}*"
+      length(var.event_source_arn) > 0 ? "${regex("arn.*\\/", var.event_source_arn)}*" : ""
     ]
   }
 

--- a/modules/event/kinesis/variables.tf
+++ b/modules/event/kinesis/variables.tf
@@ -15,10 +15,6 @@ variable "event_source_arn" {
   description = "Event source ARN of a Kinesis stream."
 }
 
-variable "stream_name" {
-  description = "Name of the Kinesis stream this Lambda function should be allowed to read records from."
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.

--- a/modules/event/kinesis/versions.tf
+++ b/modules/event/kinesis/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
- infer IAM policy from `event_source_arn` for dynamodb and kinesis
- use same variables for dynamodb and kinesis sub-modules

**this should be released as new minor version**